### PR TITLE
fix parse error on semaphore client [HZG-33]

### DIFF
--- a/hazelcast/src/jepsen/hazelcast.clj
+++ b/hazelcast/src/jepsen/hazelcast.clj
@@ -418,7 +418,7 @@
    )))
 
 (defn semaphore-client
-  ([] (semaphore-client nil nil false))
+  ([] (semaphore-client nil nil "false"))
   ([conn semaphore cp-direct-to-leader-routing]
    (reify client/Client
      (open! [_ test node]


### PR DESCRIPTION
Fixes 

```
ERROR [2024-07-23 18:03:06,750] main - jepsen.cli Oh jeez, I'm sorry, Jepsen broke. Here's why:
java.lang.ClassCastException: class java.lang.Boolean cannot be cast to class java.lang.String (java.lang.Boolean and java.lang.String are in module java.base of loader 'bootstrap')
	at jepsen.hazelcast$connect.invokeStatic(hazelcast.clj:137)
	at jepsen.hazelcast$connect.invoke(hazelcast.clj:130)
	at jepsen.hazelcast$semaphore_client$reify__557.open_BANG_(hazelcast.clj:425)
	at jepsen.core$run_case_BANG_$fn__13103.invoke(core.clj:212)
	at dom_top.core$real_pmap_helper$build_thread__211$fn__212.invoke(core.clj:163)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1990)
	at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1990)
	at clojure.lang.RestFn.invoke(RestFn.java:425)
	at clojure.lang.AFn.applyToHelper(AFn.java:156)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojure.core$apply.invokeStatic(core.clj:671)
	at clojure.core$bound_fn_STAR_$fn__5818.doInvoke(core.clj:2020)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.base/java.lang.Thread.run(Thread.java:840)
'semaphore' test failed
```